### PR TITLE
Let implementations of Actors throw exceptions

### DIFF
--- a/src/main/java/com/youdevise/test/narrative/Actor.java
+++ b/src/main/java/com/youdevise/test/narrative/Actor.java
@@ -11,6 +11,6 @@ package com.youdevise.test.narrative;
 public interface Actor<TYPE, IMPL extends Actor<TYPE, IMPL>> {
 	TYPE tool();
 
-    void perform(Action<TYPE, IMPL> action);
+    void perform(Action<TYPE, IMPL> action) throws Throwable;
     <DATA> DATA grabUsing(Extractor<DATA, IMPL> extractor);
 }

--- a/src/main/java/com/youdevise/test/narrative/Given.java
+++ b/src/main/java/com/youdevise/test/narrative/Given.java
@@ -24,7 +24,11 @@ public class Given<TOOL, ACTOR extends Actor<TOOL, ACTOR>> {
     }
 
     public Given<TOOL, ACTOR> was_able_to(Action<TOOL, ACTOR> action) {
-        actor.perform(action);
+        try {
+            actor.perform(action);
+        } catch (Throwable t) {
+            throw new RuntimeException(t);
+        }
         return this;
     }
 

--- a/src/main/java/com/youdevise/test/narrative/When.java
+++ b/src/main/java/com/youdevise/test/narrative/When.java
@@ -25,7 +25,11 @@ public class When<TOOL, ACTOR extends Actor<TOOL, ACTOR>> {
     }
 
     public When<TOOL, ACTOR> attempts_to(Action<TOOL, ACTOR> action) {
-        actor.perform(action);
+        try {
+            actor.perform(action);
+        } catch (Throwable e) {
+            throw new RuntimeException(e);
+        }
         return this;
     }
 

--- a/src/test/java/com/youdevise/test/narrative/GivenTest.java
+++ b/src/test/java/com/youdevise/test/narrative/GivenTest.java
@@ -1,5 +1,10 @@
 package com.youdevise.test.narrative;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.Sequence;
@@ -11,23 +16,23 @@ import org.junit.runner.RunWith;
 @RunWith(JMock.class)
 public class GivenTest {
     private Mockery context = new Mockery();
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    usesTheActorToPerformTheAction() {
+    usesTheActorToPerformTheAction() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> action = context.mock(Action.class);
-        
+
         context.checking(new Expectations() {{
             oneOf(actor).perform(action);
         }});
-        
+
         Given.the(actor).was_able_to(action);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    canPerformManyActionsInARow() {
+    canPerformManyActionsInARow() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> action = context.mock(Action.class, "first action");
         final Action<String, StringActor> otherAction = context.mock(Action.class, "second action");
@@ -41,10 +46,10 @@ public class GivenTest {
         Given.the(actor).was_able_to(action)
             .and_to(otherAction);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    canMixCallsTo_WasAbleTo_AndTo_AndTo() {
+    canMixCallsTo_WasAbleTo_AndTo_AndTo() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> firstAction = context.mock(Action.class, "first action");
         final Action<String, StringActor> secondAction = context.mock(Action.class, "second action");
@@ -63,5 +68,26 @@ public class GivenTest {
             .was_able_to(secondAction)
             .and_to(thirdAction)
             .was_able_to(fourthAction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test public void
+    canRethrowExceptionsFromActorsAsUncheckedExceptions() throws Throwable {
+        final StringActor actor = context.mock(StringActor.class);
+        final Action<String, StringActor> action = context.mock(Action.class, "first action");
+        final Throwable originalException = new Throwable("Something broke");
+
+        context.checking(new Expectations() {{
+                allowing(actor).perform(action);
+                will(throwException(originalException));
+        }});
+
+        try {
+            Given.the(actor).was_able_to(action);
+            fail();
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString("Something broke"));
+            assertThat(e.getCause(), equalTo(originalException));
+        }
     }
 }

--- a/src/test/java/com/youdevise/test/narrative/WhenTest.java
+++ b/src/test/java/com/youdevise/test/narrative/WhenTest.java
@@ -1,5 +1,10 @@
 package com.youdevise.test.narrative;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.Sequence;
@@ -11,23 +16,23 @@ import org.junit.runner.RunWith;
 @RunWith(JMock.class)
 public class WhenTest {
     private Mockery context = new Mockery();
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    usesTheActorToPerformTheAction() {
+    usesTheActorToPerformTheAction() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> action = context.mock(Action.class);
-        
+
         context.checking(new Expectations() {{
             oneOf(actor).perform(action);
         }});
-        
+
         When.the(actor).attempts_to(action);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    canPerformanManyActionsInARow() {
+    canPerformanManyActionsInARow() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> action = context.mock(Action.class, "action");
         final Action<String, StringActor> otherAction = context.mock(Action.class, "other action");
@@ -41,10 +46,10 @@ public class WhenTest {
         When.the(actor).attempts_to(action)
                        .and_to(otherAction);
     }
-    
+
     @SuppressWarnings("unchecked")
     @Test public void
-    canMixCallsTo_AttempsTo_AndTo_AndTo() {
+    canMixCallsTo_AttempsTo_AndTo_AndTo() throws Throwable {
         final StringActor actor = context.mock(StringActor.class);
         final Action<String, StringActor> firstAction = context.mock(Action.class, "first action");
         final Action<String, StringActor> secondAction = context.mock(Action.class, "second action");
@@ -63,5 +68,26 @@ public class WhenTest {
             .and_to(secondAction)
             .and_to(thirdAction)
             .attempts_to(fourthAction);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test public void
+    canRethrowExceptionsFromActorsAsUncheckedExceptions() throws Throwable {
+        final StringActor actor = context.mock(StringActor.class);
+        final Action<String, StringActor> action = context.mock(Action.class, "first action");
+        final Throwable originalException = new Throwable("Something broke");
+
+        context.checking(new Expectations() {{
+                allowing(actor).perform(action);
+                will(throwException(originalException));
+        }});
+
+        try {
+            When.the(actor).attempts_to(action);
+            fail();
+        } catch (RuntimeException e) {
+            assertThat(e.getMessage(), containsString("Something broke"));
+            assertThat(e.getCause(), equalTo(originalException));
+        }
     }
 }


### PR DESCRIPTION
This should simplify the implementations of Actor.perform() that are throwing exceptions.
Remove the need to wrap the implementations in a try/catch clause.

If this mechanism is good, then it can be expected to other methods (tool(), gradUsing()...) and possibly all other interfaces that can be implemented by users (Extractor, Action).

Eric
